### PR TITLE
escape dots for idents

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -121,7 +121,8 @@ fn create_struct_field_type(
 }
 
 fn ident(word: &str) -> Ident {
-    if is_keyword(word) {
+    let word = word.replace(".", "_");
+    if is_keyword(&word) {
         format_ident!("{}_", word)
     } else {
         format_ident!("{}", word)
@@ -355,4 +356,17 @@ pub fn create_client(cg: &CodeGen) -> Result<TokenStream> {
         }
     }
     Ok(file)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ident_odata_next_link() {
+        let idt = "odata.nextLink".to_snake_case();
+        assert_eq!(idt, "odata.next_link");
+        let idt = ident(&idt);
+        assert_eq!(idt.to_string(), "odata_next_link");
+    }
 }


### PR DESCRIPTION
This fixes a panic when running for BatchService:
```
cargo run -- --input-file=../azure-rest-api-specs/specification/batch/data-plane/Microsoft.Batch/stable/2020-03-01.11.0/BatchService.json
```

Now produces:
``` rust
    #[serde(rename = "odata.nextLink", skip_serializing_if = "Option::is_none")]
    odata_next_link: Option<String>,
```