### PR TITLE
compile on stable with optional formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 [[package]]
 name = "autorust_openapi"
 version = "0.2.0"
-source = "git+https://github.com/ctaggart/autorust_openapi#f21d16e291fd46e956216a04f61d7d3b29ba087a"
+source = "git+https://github.com/ctaggart/autorust_openapi?rev=81f0907f7adcf00cca18c89d09db80362b062096#81f0907f7adcf00cca18c89d09db80362b062096"
 dependencies = [
  "indexmap",
  "serde",
@@ -691,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b93dba1818d32e781f9d008edd577bab215e83ef50e8a1ddf1ad301b19a09f"
+checksum = "51ef7cd2518ead700af67bf9d1a658d90b6037d77110fd9c0445429d0ba1c6c9"
 dependencies = [
  "unicode-xid",
 ]
@@ -1334,9 +1334,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
+checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 [[package]]
 name = "autorust_openapi"
 version = "0.2.0"
-source = "git+https://github.com/ctaggart/autorust_openapi#81f0907f7adcf00cca18c89d09db80362b062096"
+source = "git+https://github.com/ctaggart/autorust_openapi#f21d16e291fd46e956216a04f61d7d3b29ba087a"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/main.rs"
 autorust_openapi = { git = "https://github.com/ctaggart/autorust_openapi" }
 # autorust_openapi = { path = "../autorust_openapi" }
 quote = "*"
-rustfmt-nightly = { git = "https://github.com/rust-lang/rustfmt" }
 proc-macro2 = { version = "*", default-features = false }
 serde_json = "*"
 heck = "*"
@@ -24,3 +23,7 @@ regex = "*"
 indexmap = {version = "*", features = ["serde-1"]}
 path_abs = "*"
 clap = "3.0.0-beta.2"
+rustfmt-nightly = { git = "https://github.com/rust-lang/rustfmt", optional = true }
+
+[features]
+fmt = ["rustfmt-nightly"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "autorust"
 path = "src/main.rs"
 
 [dependencies]
-autorust_openapi = { git = "https://github.com/ctaggart/autorust_openapi" }
+autorust_openapi = { git = "https://github.com/ctaggart/autorust_openapi", rev = "81f0907f7adcf00cca18c89d09db80362b062096" }
 # autorust_openapi = { path = "../autorust_openapi" }
 quote = "*"
 proc-macro2 = { version = "*", default-features = false }

--- a/README.md
+++ b/README.md
@@ -4,11 +4,18 @@ A command line app similar to [AutoRest](https://github.com/azure/autorest), but
 
 ## Buliding
 
-The [rustfmt-nightly](https://github.com/rust-lang/rustfmt) dependency requires that a couple of environment variables be set.
+By default building the project is very straight forward:
+```sh
+cargo build
+```
+
+### Formatting
+
+If you want to format the generated code, you'll need to use a nightly compiler and ensure that the `fmt` feature is enabled. Additionally, the [rustfmt-nightly](https://github.com/rust-lang/rustfmt) dependency requires that a couple of environment variables be set.
 ``` sh
 export CFG_RELEASE_CHANNEL=nightly
 export CFG_RELEASE=nightly
-cargo build
+cargo +nightly build --features fmt
 ```
 
 ## Running

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -267,7 +267,7 @@ fn create_function_params(cg: &CodeGen, op: &Operation) -> Result<TokenStream> {
 
 fn get_type_for_schema(schema: &ReferenceOr<Schema>) -> Result<TokenStream> {
     match schema {
-        ReferenceOr::Reference { reference } => {
+        ReferenceOr::Reference { reference, .. } => {
             let rf = Reference::parse(&reference)?;
             let idt = ident(
                 &rf.name

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "fmt")]
 pub fn format_code(unformatted: String) -> String {
     let mut config = rustfmt_nightly::Config::default();
     config.set().edition(rustfmt_nightly::Edition::Edition2018);
@@ -24,4 +25,9 @@ pub fn format_code(unformatted: String) -> String {
         },
         Err(_err) => unformatted,
     }
+}
+
+#[cfg(not(feature = "fmt"))]
+pub fn format_code(unformatted: String) -> String {
+    unformatted
 }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -48,7 +48,7 @@ impl Spec {
         for (file, doc) in &docs {
             for (name, schema) in &doc.definitions {
                 match schema {
-                    ReferenceOr::Reference { reference: _, .. } => {}
+                    ReferenceOr::Reference { .. } => {}
                     ReferenceOr::Item(schema) => {
                         // println!("insert schema {} {}", &file, &name);
                         schemas.insert(
@@ -142,7 +142,7 @@ impl Spec {
     pub fn resolve_path(&self, _doc_file: &str, path: &ReferenceOr<PathItem>) -> Result<PathItem> {
         match path {
             ReferenceOr::Item(path) => Ok(path.clone()),
-            ReferenceOr::Reference { reference: _, .. } =>
+            ReferenceOr::Reference { .. } =>
             // self.resolve_path_ref(doc_file, reference),
             {
                 Err("path references not implemented")?

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -48,7 +48,7 @@ impl Spec {
         for (file, doc) in &docs {
             for (name, schema) in &doc.definitions {
                 match schema {
-                    ReferenceOr::Reference { reference: _ } => {}
+                    ReferenceOr::Reference { reference: _, .. } => {}
                     ReferenceOr::Item(schema) => {
                         // println!("insert schema {} {}", &file, &name);
                         schemas.insert(
@@ -121,7 +121,9 @@ impl Spec {
     pub fn resolve_schema(&self, doc_file: &str, schema: &ReferenceOr<Schema>) -> Result<Schema> {
         match schema {
             ReferenceOr::Item(schema) => Ok(schema.clone()),
-            ReferenceOr::Reference { reference } => self.resolve_schema_ref(doc_file, reference),
+            ReferenceOr::Reference { reference, .. } => {
+                self.resolve_schema_ref(doc_file, reference)
+            }
         }
     }
 
@@ -140,7 +142,7 @@ impl Spec {
     pub fn resolve_path(&self, _doc_file: &str, path: &ReferenceOr<PathItem>) -> Result<PathItem> {
         match path {
             ReferenceOr::Item(path) => Ok(path.clone()),
-            ReferenceOr::Reference { reference: _ } =>
+            ReferenceOr::Reference { reference: _, .. } =>
             // self.resolve_path_ref(doc_file, reference),
             {
                 Err("path references not implemented")?
@@ -167,7 +169,9 @@ impl Spec {
     ) -> Result<Parameter> {
         match parameter {
             ReferenceOr::Item(param) => Ok(param.clone()),
-            ReferenceOr::Reference { reference } => self.resolve_parameter_ref(doc_file, reference),
+            ReferenceOr::Reference { reference, .. } => {
+                self.resolve_parameter_ref(doc_file, reference)
+            }
         }
     }
 
@@ -227,7 +231,7 @@ impl ToString for RefString {
 fn add_refs_for_schema(list: &mut Vec<RefString>, schema: &Schema) {
     for (_, schema) in &schema.properties {
         match schema {
-            ReferenceOr::Reference { reference } => {
+            ReferenceOr::Reference { reference, .. } => {
                 list.push(RefString::Schema(reference.to_owned()))
             }
             ReferenceOr::Item(schema) => add_refs_for_schema(list, schema),
@@ -235,7 +239,7 @@ fn add_refs_for_schema(list: &mut Vec<RefString>, schema: &Schema) {
     }
     match schema.additional_properties.as_ref() {
         Some(schema) => match schema {
-            ReferenceOr::Reference { reference } => {
+            ReferenceOr::Reference { reference, .. } => {
                 list.push(RefString::Schema(reference.to_owned()))
             }
             ReferenceOr::Item(schema) => add_refs_for_schema(list, schema),
@@ -244,7 +248,7 @@ fn add_refs_for_schema(list: &mut Vec<RefString>, schema: &Schema) {
     }
     match schema.items.as_ref() {
         Some(schema) => match schema {
-            ReferenceOr::Reference { reference } => {
+            ReferenceOr::Reference { reference, .. } => {
                 list.push(RefString::Schema(reference.to_owned()))
             }
             ReferenceOr::Item(schema) => add_refs_for_schema(list, schema),
@@ -253,7 +257,7 @@ fn add_refs_for_schema(list: &mut Vec<RefString>, schema: &Schema) {
     }
     for schema in &schema.all_of {
         match schema {
-            ReferenceOr::Reference { reference } => {
+            ReferenceOr::Reference { reference, .. } => {
                 list.push(RefString::Schema(reference.to_owned()))
             }
             ReferenceOr::Item(schema) => add_refs_for_schema(list, schema),
@@ -268,7 +272,7 @@ pub fn get_refs(api: &OpenAPI) -> Vec<RefString> {
     // paths and operations
     for (_path, item) in &api.paths {
         match item {
-            ReferenceOr::Reference { reference } => {
+            ReferenceOr::Reference { reference, .. } => {
                 list.push(RefString::PathItem(reference.to_owned()))
             }
             ReferenceOr::Item(item) => {
@@ -276,11 +280,11 @@ pub fn get_refs(api: &OpenAPI) -> Vec<RefString> {
                     // parameters
                     for prm in &op.parameters {
                         match prm {
-                            ReferenceOr::Reference { reference } => {
+                            ReferenceOr::Reference { reference, .. } => {
                                 list.push(RefString::Parameter(reference.to_owned()))
                             }
                             ReferenceOr::Item(parameter) => match &parameter.schema {
-                                Some(ReferenceOr::Reference { reference }) => {
+                                Some(ReferenceOr::Reference { reference, .. }) => {
                                     list.push(RefString::Schema(reference.to_owned()))
                                 }
                                 Some(ReferenceOr::Item(schema)) => {
@@ -294,7 +298,7 @@ pub fn get_refs(api: &OpenAPI) -> Vec<RefString> {
                     // responses
                     for (_code, rsp) in &op.responses {
                         match &rsp.schema {
-                            Some(ReferenceOr::Reference { reference }) => {
+                            Some(ReferenceOr::Reference { reference, .. }) => {
                                 list.push(RefString::Schema(reference.to_owned()))
                             }
                             Some(ReferenceOr::Item(schema)) => {
@@ -307,7 +311,7 @@ pub fn get_refs(api: &OpenAPI) -> Vec<RefString> {
                     // examples
                     for (_name, example) in &op.x_ms_examples {
                         match example {
-                            ReferenceOr::Reference { reference } => {
+                            ReferenceOr::Reference { reference, .. } => {
                                 list.push(RefString::Example(reference.to_owned()))
                             }
                             _ => {}
@@ -321,7 +325,7 @@ pub fn get_refs(api: &OpenAPI) -> Vec<RefString> {
     // definitions
     for (_name, schema) in &api.definitions {
         match schema {
-            ReferenceOr::Reference { reference } => {
+            ReferenceOr::Reference { reference, .. } => {
                 list.push(RefString::Schema(reference.to_owned()))
             }
             ReferenceOr::Item(schema) => add_refs_for_schema(&mut list, schema),


### PR DESCRIPTION
This removes the direct dependency on a nightly compiler. Users can now opt into formatting the code which will opt them into a nightly compiler.

This almost compiles, but due to a change in https://github.com/ctaggart/autorust_openapi/pull/18 which changed enums from `String`s to `serde_json::Value`s, one piece of code does not compile. I'm not entirely sure if the change in https://github.com/ctaggart/autorust_openapi/pull/18 is correct, as I can't imagine how an enum would be modeled as an bools, numbers, etc. 