### PR TITLE
multiple input files

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -48,11 +48,13 @@ impl CodeGen {
 
         // any referenced schemas from other files
         for (doc_file, doc) in &self.spec.docs {
-            for rf in get_schema_refs(doc) {
-                let schema = self.spec.resolve_schema_ref(doc_file, &rf)?;
-                if !self.spec.is_input_file(doc_file) {
+            if self.spec.is_input_file(doc_file) {
+                for rf in get_schema_refs(doc) {
+                    let schema = self.spec.resolve_schema_ref(doc_file, &rf)?;
                     if let Some(ref_key) = &schema.ref_key {
-                        all_schemas.insert(ref_key.clone(), schema);
+                        if !self.spec.is_input_file(&ref_key.file) {
+                            all_schemas.insert(ref_key.clone(), schema);
+                        }
                     }
                 }
             }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -73,12 +73,6 @@ impl CodeGen {
         for (doc_file, doc) in &self.spec.docs {
             if self.spec.is_input_file(doc_file) {
                 for rf in get_api_schema_refs(doc) {
-                    // let schema = self.spec.resolve_schema_ref(doc_file, &rf)?;
-                    // if let Some(ref_key) = &schema.ref_key {
-                    //     if !self.spec.is_input_file(&ref_key.file) {
-                    //         all_schemas.insert(ref_key.clone(), schema);
-                    //     }
-                    // }
                     self.add_schema_refs(&mut all_schemas, doc_file, &rf)?;
                 }
             }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -461,7 +461,8 @@ fn get_type_name_for_schema_ref(schema: &ReferenceOr<Schema>) -> Result<TokenStr
             let rf = Reference::parse(&reference)?;
             let idt = ident(
                 &rf.name
-                    .ok_or_else(|| format!("no name for ref {}", reference))?,
+                    .ok_or_else(|| format!("no name for ref {}", reference))?
+                    .to_camel_case(),
             );
             Ok(quote! { #idt })
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,19 +11,17 @@ use std::{
 fn main() -> Result<()> {
     let config = cli::Config::try_new()?;
     fs::create_dir_all(config.output_folder())?;
-    for input_file in config.input_files() {
-        let cg = &CodeGen::from_file(input_file)?;
+    let cg = &CodeGen::from_files(config.input_files())?;
 
-        // create models from schemas
-        let models = cg.create_models()?;
-        let models_path = path::join(config.output_folder(), "models.rs")?;
-        write_file(&models_path, &models)?;
+    // create models from schemas
+    let models = cg.create_models()?;
+    let models_path = path::join(config.output_folder(), "models.rs")?;
+    write_file(&models_path, &models)?;
 
-        // create api client from operations
-        let client = cg.create_client()?;
-        let client_path = path::join(&config.output_folder(), "client.rs")?;
-        write_file(&client_path, &client)?;
-    }
+    // create api client from operations
+    let client = cg.create_client()?;
+    let client_path = path::join(&config.output_folder(), "client.rs")?;
+    write_file(&client_path, &client)?;
     Ok(())
 }
 

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -426,9 +426,20 @@ pub fn get_ref_files(api: &OpenAPI) -> Result<IndexSet<String>> {
     Ok(set)
 }
 
-pub fn get_schema_refs(api: &OpenAPI) -> Vec<String> {
+pub fn get_api_schema_refs(api: &OpenAPI) -> Vec<String> {
     get_refs(api)
         .iter()
+        .filter_map(|rf| match rf {
+            RefString::Schema(rs) => Some(rs.to_owned()),
+            _ => None,
+        })
+        .collect()
+}
+
+pub fn get_schema_schema_refs(schema: &Schema) -> Vec<String> {
+    let mut refs = Vec::new();
+    add_refs_for_schema(&mut refs, schema);
+    refs.iter()
         .filter_map(|rf| match rf {
             RefString::Schema(rs) => Some(rs.to_owned()),
             _ => None,

--- a/tests/azure_rest_api_specs.rs
+++ b/tests/azure_rest_api_specs.rs
@@ -35,7 +35,7 @@ fn ref_files() -> Result<()> {
 
 #[test]
 fn read_spec_avs() -> Result<()> {
-    let spec = &Spec::read_file("../azure-rest-api-specs/specification/vmware/resource-manager/Microsoft.AVS/stable/2020-03-20/vmware.json")?;
+    let spec = &Spec::read_files(&["../azure-rest-api-specs/specification/vmware/resource-manager/Microsoft.AVS/stable/2020-03-20/vmware.json"])?;
     assert_eq!(2, spec.docs.len());
     assert!(spec.docs.contains_key(std::path::Path::new(
         "../azure-rest-api-specs/specification/common-types/resource-management/v1/types.json"
@@ -46,7 +46,7 @@ fn read_spec_avs() -> Result<()> {
 #[test]
 fn test_resolve_schema_ref() -> Result<()> {
     let file = PathBuf::from("../azure-rest-api-specs/specification/vmware/resource-manager/Microsoft.AVS/stable/2020-03-20/vmware.json");
-    let spec = &Spec::read_file(&file)?;
+    let spec = &Spec::read_files(&[&file])?;
     spec.resolve_schema_ref(&file, "#/definitions/OperationList")?;
     spec.resolve_schema_ref(
         &file,
@@ -58,7 +58,7 @@ fn test_resolve_schema_ref() -> Result<()> {
 #[test]
 fn test_resolve_parameter_ref() -> Result<()> {
     let file = PathBuf::from("../azure-rest-api-specs/specification/vmware/resource-manager/Microsoft.AVS/stable/2020-03-20/vmware.json");
-    let spec = &Spec::read_file(&file)?;
+    let spec = &Spec::read_files(&[&file])?;
     spec.resolve_parameter_ref(&file, "../../../../../common-types/resource-management/v1/types.json#/parameters/ApiVersionParameter")?;
     Ok(())
 }
@@ -66,17 +66,19 @@ fn test_resolve_parameter_ref() -> Result<()> {
 #[test]
 fn test_resolve_all_refs() -> Result<()> {
     let doc_file = PathBuf::from("../azure-rest-api-specs/specification/vmware/resource-manager/Microsoft.AVS/stable/2020-03-20/vmware.json");
-    let spec = &Spec::read_file(&doc_file)?;
-    let refs = spec::get_refs(spec.root_doc());
-    for rs in refs {
-        match rs {
-            RefString::PathItem(_) => {}
-            RefString::Example(_) => {}
-            RefString::Parameter(reference) => {
-                spec.resolve_parameter_ref(&doc_file, &reference)?;
-            }
-            RefString::Schema(reference) => {
-                spec.resolve_schema_ref(&doc_file, &reference)?;
+    let spec = &Spec::read_files(&[&doc_file])?;
+    for (doc_file, doc) in &spec.docs {
+        let refs = spec::get_refs(doc);
+        for rs in refs {
+            match rs {
+                RefString::PathItem(_) => {}
+                RefString::Example(_) => {}
+                RefString::Parameter(reference) => {
+                    spec.resolve_parameter_ref(&doc_file, &reference)?;
+                }
+                RefString::Schema(reference) => {
+                    spec.resolve_schema_ref(&doc_file, &reference)?;
+                }
             }
         }
     }


### PR DESCRIPTION
Makes this work:
``` bash
cargo run --features fmt -- \
--output-folder ../azure-sdk-for-rust/rest/azure_mgmt_storage_v2019_06_01/src/ \
--input-file ../azure-rest-api-specs/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/storage.json \
--input-file ../azure-rest-api-specs/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/blob.json \
--input-file ../azure-rest-api-specs/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/file.json \
--input-file ../azure-rest-api-specs/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/queue.json \
--input-file ../azure-rest-api-specs/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/table.json
```