### PR TITLE
add HttpClientArc & set user-agent

### DIFF
--- a/codegen/examples/avs_mgmt.rs
+++ b/codegen/examples/avs_mgmt.rs
@@ -2,6 +2,7 @@
 // https://github.com/Azure/azure-rest-api-specs/blob/master/specification/vmware/resource-manager
 
 use autorust_codegen::*;
+use std::collections::HashSet;
 
 fn main() -> Result<()> {
     let api_version = "2020-03-20";
@@ -11,6 +12,7 @@ fn main() -> Result<()> {
         api_version: Some(api_version.to_owned()),
         output_folder: output_folder.into(),
         input_files: input_files.iter().map(Into::into).collect(),
+        box_properties: HashSet::new(),
     })?;
 
     Ok(())

--- a/codegen/examples/gen_mgmt.rs
+++ b/codegen/examples/gen_mgmt.rs
@@ -13,7 +13,8 @@ const SPEC_FOLDER: &str = "../azure-rest-api-specs/specification";
 const OUTPUT_FOLDER: &str = "../azure-sdk-for-rust/services/mgmt";
 
 const ONLY_SERVICES: &[&str] = &[
-    // "vmware",
+    // "resources",
+    // "vmware"
 ];
 
 const SKIP_SERVICES: &[&str] = &[
@@ -130,7 +131,6 @@ fn gen_crate(spec_folder: &str) -> Result<()> {
 
     let service_name = &get_service_name(spec_folder);
     // println!("{} -> {}", spec_folder, service_name);
-    let crate_name = &format!("azure_mgmt_{}", service_name);
     let output_folder = &path::join(OUTPUT_FOLDER, service_name).context(PathError)?;
 
     let src_folder = path::join(output_folder, "src").context(PathError)?;
@@ -190,12 +190,17 @@ fn gen_crate(spec_folder: &str) -> Result<()> {
         return Ok(());
     }
     cargo_toml::create(
-        crate_name,
+        &format!("azure_mgmt_{}", service_name),
         &feature_mod_names,
         &path::join(output_folder, "Cargo.toml").context(PathError)?,
     )
     .context(CargoTomlError)?;
-    lib_rs::create(&feature_mod_names, &path::join(src_folder, "lib.rs").context(PathError)?).context(LibRsError)?;
+    lib_rs::create(
+        &format!("mgmt_{}", service_name),
+        &feature_mod_names,
+        &path::join(src_folder, "lib.rs").context(PathError)?,
+    )
+    .context(LibRsError)?;
 
     Ok(())
 }

--- a/codegen/examples/resources_mgmt.rs
+++ b/codegen/examples/resources_mgmt.rs
@@ -2,6 +2,7 @@
 // https://github.com/Azure/azure-rest-api-specs/tree/master/specification/resources/resource-manager
 
 use autorust_codegen::*;
+use std::collections::HashSet;
 
 fn main() -> Result<()> {
     let api_version = "2020-06-01";
@@ -12,6 +13,7 @@ fn main() -> Result<()> {
         api_version: Some(api_version.to_owned()),
         output_folder: output_folder.into(),
         input_files: input_files.iter().map(Into::into).collect(),
+        box_properties: HashSet::new(),
     })?;
 
     Ok(())

--- a/codegen/examples/storage_mgmt.rs
+++ b/codegen/examples/storage_mgmt.rs
@@ -2,6 +2,7 @@
 // https://github.com/Azure/azure-rest-api-specs/tree/master/specification/storage/resource-manager
 
 use autorust_codegen::*;
+use std::collections::HashSet;
 
 fn main() -> Result<()> {
     let api_version = "2020-08-01-preview";
@@ -17,6 +18,7 @@ fn main() -> Result<()> {
         api_version: Some(api_version.to_owned()),
         output_folder: output_folder.into(),
         input_files: input_files.iter().map(Into::into).collect(),
+        box_properties: HashSet::new(),
     })?;
 
     let api_version = "2019-06-01";
@@ -32,6 +34,7 @@ fn main() -> Result<()> {
         api_version: Some(api_version.to_owned()),
         output_folder: output_folder.into(),
         input_files: input_files.iter().map(Into::into).collect(),
+        box_properties: HashSet::new(),
     })?;
 
     Ok(())

--- a/codegen/src/codegen.rs
+++ b/codegen/src/codegen.rs
@@ -918,6 +918,9 @@ fn create_function(
             let client = operation_config.http_client();
             let uri_str = &format!(#fpath, operation_config.base_path(), #uri_str_args);
             let mut req_builder = #client_verb;
+            if let Some(user_agent) = operation_config.user_agent(){
+                req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent);
+            }
             #ts_request_builder
             let req = req_builder.build().context(#fname::BuildRequestError)?;
             let rsp = client.execute(req).await.context(#fname::ExecuteRequestError)?;

--- a/codegen/src/codegen.rs
+++ b/codegen/src/codegen.rs
@@ -479,8 +479,7 @@ fn create_function_params(_cg: &CodeGen, _doc_file: &Path, parameters: &Vec<Para
         let tp = get_param_type(param)?;
         params.push(quote! { #name: #tp });
     }
-    let slf = quote! { operation_config: &crate::OperationConfig };
-    params.insert(0, slf);
+    params.insert(0, quote! { operation_config: &crate::OperationConfig<'a> });
     Ok(quote! { #(#params),* })
 }
 
@@ -917,7 +916,7 @@ fn create_function(
     }
 
     let func = quote! {
-        pub async fn #fname(#fparams) -> #fresponse {
+        pub async fn #fname<'a>(#fparams) -> #fresponse {
             let client = &operation_config.client;
             let uri_str = &format!(#fpath, &operation_config.base_path, #uri_str_args);
             let mut req_builder = #client_verb;

--- a/codegen/src/codegen.rs
+++ b/codegen/src/codegen.rs
@@ -623,12 +623,10 @@ fn create_function(
 
     // auth
     ts_request_builder.extend(quote! {
-        if let Some(token_credential) = &operation_config.token_credential {
-            let token_response = token_credential
-                .get_token(&operation_config.token_credential_resource).await
-                .context(#fname::GetTokenError)?;
-            req_builder = req_builder.bearer_auth(token_response.token.secret());
-        }
+        let token_response = operation_config.token_credential
+            .get_token(&operation_config.token_credential_resource).await
+            .context(#fname::GetTokenError)?;
+        req_builder = req_builder.bearer_auth(token_response.token.secret());
     });
 
     // api-version param

--- a/codegen/src/lib_rs.rs
+++ b/codegen/src/lib_rs.rs
@@ -42,42 +42,50 @@ fn create_body(feature_mod_names: &Vec<(String, String)>) -> Result<TokenStream>
         #generated_by
         #cfgs
 
+        #[derive(Clone)]
         pub struct OperationConfig<'a> {
-            api_version: String,
-            client: reqwest::Client,
-            base_path: String,
-            token_credential: Option<&'a dyn azure_core::TokenCredential>,
+            client: &'a reqwest::Client,
+            token_credential: &'a dyn azure_core::TokenCredential,
             token_credential_resource: String,
+            base_path: String,
+            api_version: String,
         }
 
         impl<'a> OperationConfig<'a> {
-            pub fn new(token_credential: &'a dyn azure_core::TokenCredential) -> Self {
-                let mut config = Self::default();
-                config.set_token_credential(token_credential);
-                config
+            pub fn new(client: &'a reqwest::Client, token_credential: &'a dyn azure_core::TokenCredential) -> Self {
+                Self {
+                    client,
+                    token_credential,
+                    token_credential_resource: "https://management.azure.com/".to_owned(),
+                    base_path: "https://management.azure.com".to_owned(),
+                    api_version: API_VERSION.to_owned(),
+                }
             }
-            pub fn set_api_version(&mut self, api_version: String){
-                self.api_version = api_version;
+            pub fn new_all(
+                client: &'a reqwest::Client,
+                token_credential: &'a dyn azure_core::TokenCredential,
+                token_credential_resource: String,
+                base_path: String,
+                api_version: String,
+            ) -> Self {
+                Self {
+                    client,
+                    token_credential,
+                    token_credential_resource,
+                    base_path,
+                    api_version,
+                }
             }
-            pub fn api_version(&self) -> &str {
-                &self.api_version
-            }
-            pub fn set_client(&mut self, client: reqwest::Client){
+            pub fn set_client(&mut self, client: &'a reqwest::Client){
                 self.client = client;
             }
-            pub fn client(&self) -> &reqwest::Client {
-                &self.client
-            }
-            pub fn set_base_path(&mut self, base_path: String){
-                self.base_path = base_path;
-            }
-            pub fn base_path(&self) -> &str {
-                &self.base_path
+            pub fn client(&self) -> &'a reqwest::Client {
+                self.client
             }
             pub fn set_token_credential(&mut self, token_credential: &'a dyn azure_core::TokenCredential){
-                self.token_credential = Some(token_credential);
+                self.token_credential = token_credential;
             }
-            pub fn token_credential(&self) -> Option<&'a dyn azure_core::TokenCredential> {
+            pub fn token_credential(&self) -> &'a dyn azure_core::TokenCredential {
                 self.token_credential
             }
             pub fn set_token_credential_resource(&mut self, token_credential_resource: String){
@@ -86,18 +94,19 @@ fn create_body(feature_mod_names: &Vec<(String, String)>) -> Result<TokenStream>
             pub fn token_credential_resource(&self) -> &str {
                 &self.token_credential_resource
             }
-        }
-
-        impl<'a> Default for OperationConfig<'a> {
-            fn default() -> Self {
-                Self {
-                    api_version: API_VERSION.to_owned(),
-                    client: reqwest::Client::new(),
-                    base_path: "https://management.azure.com".to_owned(),
-                    token_credential: None,
-                    token_credential_resource: "https://management.azure.com/".to_owned(),
-                }
+            pub fn set_base_path(&mut self, base_path: String){
+                self.base_path = base_path;
+            }
+            pub fn base_path(&self) -> &str {
+                &self.base_path
+            }
+            pub fn set_api_version(&mut self, api_version: String){
+                self.api_version = api_version;
+            }
+            pub fn api_version(&self) -> &str {
+                &self.api_version
             }
         }
+
     })
 }

--- a/codegen/src/lib_rs.rs
+++ b/codegen/src/lib_rs.rs
@@ -43,18 +43,18 @@ fn create_body(feature_mod_names: &Vec<(String, String)>) -> Result<TokenStream>
         #cfgs
 
         #[derive(Clone)]
-        pub struct OperationConfig<'a> {
-            client: &'a reqwest::Client,
-            token_credential: &'a dyn azure_core::TokenCredential,
+        pub struct OperationConfig {
+            http_client: azure_core::HttpClientArc,
+            token_credential: azure_core::TokenCredentialArc,
             token_credential_resource: String,
             base_path: String,
             api_version: String,
         }
 
-        impl<'a> OperationConfig<'a> {
-            pub fn new(client: &'a reqwest::Client, token_credential: &'a dyn azure_core::TokenCredential) -> Self {
+        impl OperationConfig {
+            pub fn new(http_client: azure_core::HttpClientArc, token_credential: azure_core::TokenCredentialArc) -> Self {
                 Self {
-                    client,
+                    http_client,
                     token_credential,
                     token_credential_resource: "https://management.azure.com/".to_owned(),
                     base_path: "https://management.azure.com".to_owned(),
@@ -62,31 +62,25 @@ fn create_body(feature_mod_names: &Vec<(String, String)>) -> Result<TokenStream>
                 }
             }
             pub fn new_all(
-                client: &'a reqwest::Client,
-                token_credential: &'a dyn azure_core::TokenCredential,
+                http_client: azure_core::HttpClientArc,
+                token_credential: azure_core::TokenCredentialArc,
                 token_credential_resource: String,
                 base_path: String,
                 api_version: String,
             ) -> Self {
                 Self {
-                    client,
+                    http_client,
                     token_credential,
                     token_credential_resource,
                     base_path,
                     api_version,
                 }
             }
-            pub fn set_client(&mut self, client: &'a reqwest::Client){
-                self.client = client;
+            pub fn http_client(&self) -> &reqwest::Client {
+                self.http_client.as_ref()
             }
-            pub fn client(&self) -> &'a reqwest::Client {
-                self.client
-            }
-            pub fn set_token_credential(&mut self, token_credential: &'a dyn azure_core::TokenCredential){
-                self.token_credential = token_credential;
-            }
-            pub fn token_credential(&self) -> &'a dyn azure_core::TokenCredential {
-                self.token_credential
+            pub fn token_credential(&self) -> &dyn azure_core::TokenCredential {
+                self.token_credential.as_ref().as_ref()
             }
             pub fn set_token_credential_resource(&mut self, token_credential_resource: String){
                 self.token_credential_resource = token_credential_resource;

--- a/codegen/src/lib_rs.rs
+++ b/codegen/src/lib_rs.rs
@@ -42,24 +42,53 @@ fn create_body(feature_mod_names: &Vec<(String, String)>) -> Result<TokenStream>
         #generated_by
         #cfgs
 
-        pub struct OperationConfig {
-            pub api_version: String,
-            pub client: reqwest::Client,
-            pub base_path: String,
-            pub token_credential: Option<Box<dyn azure_core::TokenCredential>>,
-            pub token_credential_resource: String,
+        pub struct OperationConfig<'a> {
+            api_version: String,
+            client: reqwest::Client,
+            base_path: String,
+            token_credential: Option<&'a dyn azure_core::TokenCredential>,
+            token_credential_resource: String,
         }
 
-        impl OperationConfig {
-            pub fn new(token_credential: Box<dyn azure_core::TokenCredential>) -> Self {
-                Self {
-                    token_credential: Some(token_credential),
-                    ..Default::default()
-                }
+        impl<'a> OperationConfig<'a> {
+            pub fn new(token_credential: &'a dyn azure_core::TokenCredential) -> Self {
+                let mut config = Self::default();
+                config.set_token_credential(token_credential);
+                config
+            }
+            pub fn set_api_version(&mut self, api_version: String){
+                self.api_version = api_version;
+            }
+            pub fn api_version(&self) -> &str {
+                &self.api_version
+            }
+            pub fn set_client(&mut self, client: reqwest::Client){
+                self.client = client;
+            }
+            pub fn client(&self) -> &reqwest::Client {
+                &self.client
+            }
+            pub fn set_base_path(&mut self, base_path: String){
+                self.base_path = base_path;
+            }
+            pub fn base_path(&self) -> &str {
+                &self.base_path
+            }
+            pub fn set_token_credential(&mut self, token_credential: &'a dyn azure_core::TokenCredential){
+                self.token_credential = Some(token_credential);
+            }
+            pub fn token_credential(&self) -> Option<&'a dyn azure_core::TokenCredential> {
+                self.token_credential
+            }
+            pub fn set_token_credential_resource(&mut self, token_credential_resource: String){
+                self.token_credential_resource = token_credential_resource;
+            }
+            pub fn token_credential_resource(&self) -> &str {
+                &self.token_credential_resource
             }
         }
 
-        impl Default for OperationConfig {
+        impl<'a> Default for OperationConfig<'a> {
             fn default() -> Self {
                 Self {
                     api_version: API_VERSION.to_owned(),


### PR DESCRIPTION
This allows passing in TokenCredential as a reference to more than one OperationConfig. It also adds getters and setters. I'm waiting on https://github.com/Azure/azure-sdk-for-rust/pull/71 to merge.